### PR TITLE
Fix possessive grammar in computer tests

### DIFF
--- a/tests/computer.test.js
+++ b/tests/computer.test.js
@@ -20,14 +20,14 @@ describe('This suite will test the Computer class functionality', () => {
         expect(shipsPlaced.size).toBe(5);
     });
 
-    test('Computer attacks on opponents game board is handled correctly', async () => {
+    test('Computer attacks on opponent\'s game board is handled correctly', async () => {
         let player = new Player('Chief');
         player.randomPlaceShip();
 
         computer.randomPlaceShip();
         computer.targetField = player.playerField;
 
-        // Deep copy to preserve the opponents board
+        // Deep copy to preserve the opponent's board
         let initialOpponentBoard = JSON.parse(
             JSON.stringify(computer.opponentBoard.field)
         );


### PR DESCRIPTION
## Summary
- use opponent's possessive in computer attack test description
- clarify comment about preserving opponent's board

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6890f8ceed8c8322bb7b02e6be06f15c