### PR TITLE
Fix random ship selection in randomPlaceShip

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -316,8 +316,7 @@ class Player {
 
     randomPlaceShip() {
         while (this.ships.length) {
-            const randomIndex =
-                this.ships[Math.floor(Math.random() * this.ships.length)];
+            const randomIndex = Math.floor(Math.random() * this.ships.length);
             const randomShip = this.ships.splice(randomIndex, 1)[0];
             try {
                 const xCor = Math.floor(Math.random() * 10);


### PR DESCRIPTION
## Summary
- ensure randomPlaceShip selects a ship index before splicing the array

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6890f8ea39a48322a51236c7382ddea7