### PR TITLE
Fix ship test to avoid extra hit

### DIFF
--- a/tests/ship.test.js
+++ b/tests/ship.test.js
@@ -13,7 +13,6 @@ describe('Ship', () => {
     });
 
     test(`This will check the ship hasn't sunk after one hit`, () => {
-        testShip.hit();
         expect(testShip.sunk).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- remove redundant hit call in ship test

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6890f8f740a883229a57b36142afef66