### PR TITLE
chore: enable esm tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+    testEnvironment: 'node',
+    moduleNameMapper: {
+        '\\.(css|less|scss|sass|png|svg|jpg|jpeg|gif)$':
+            '<rootDir>/tests/__mocks__/fileMock.js',
+    },
+};

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
     "version": "1.0.0",
     "description": "Battleship, the game. Built as a project from The Odin Project.",
     "private": true,
+    "type": "module",
     "scripts": {
-        "test": "jest",
+        "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "gh-deploy": "git push origin :gh-pages && git subtree push --prefix dist origin gh-pages",
         "gh-deploy-init": "git push origin && git subtree push --prefix dist origin gh-pages"
     },

--- a/src/computer.js
+++ b/src/computer.js
@@ -1,4 +1,4 @@
-import Player from './player';
+import Player from './player.js';
 
 class Computer extends Player {
     constructor() {

--- a/src/gameBoard.js
+++ b/src/gameBoard.js
@@ -1,4 +1,4 @@
-import Ship from './ships';
+import Ship from './ships.js';
 
 class GameBoard {
     constructor() {

--- a/src/gameFields/fieldCreation.js
+++ b/src/gameFields/fieldCreation.js
@@ -1,4 +1,4 @@
-import Ship from '../ships';
+import Ship from '../ships.js';
 
 class FieldCreation {
     static makeField(thisBoard, thisField, i, j, shipsContainer) {

--- a/src/gameFunctions/gameLoop.js
+++ b/src/gameFunctions/gameLoop.js
@@ -1,10 +1,10 @@
-import Player from '../player';
-import Computer from '../computer';
-import inputHandler from './inputHandler';
-import PlayerMove from './playerMove';
-import GameStatus from './gameStatus';
-import ComputerMove from './computerMove';
-import GameBoard from '../gameBoard';
+import Player from '../player.js';
+import Computer from '../computer.js';
+import inputHandler from './inputHandler.js';
+import PlayerMove from './playerMove.js';
+import GameStatus from './gameStatus.js';
+import ComputerMove from './computerMove.js';
+import GameBoard from '../gameBoard.js';
 
 class GameLoop {
     constructor() {

--- a/src/gameFunctions/gameStatus.js
+++ b/src/gameFunctions/gameStatus.js
@@ -1,4 +1,4 @@
-import Ship from '../ships';
+import Ship from '../ships.js';
 
 class GameStatus {
     static endGame() {

--- a/src/gameFunctions/playerMove.js
+++ b/src/gameFunctions/playerMove.js
@@ -1,4 +1,4 @@
-import Ship from '../ships';
+import Ship from '../ships.js';
 
 class PlayerMove {
     static async move(oppBoard) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import './style.css';
-import screenRender from './screenRender';
-import FieldCreation from './gameFields/fieldCreation';
-import GameLoop from './gameFunctions/gameLoop';
+import screenRender from './screenRender.js';
+import FieldCreation from './gameFields/fieldCreation.js';
+import GameLoop from './gameFunctions/gameLoop.js';
 
 (async () => {
     let game;

--- a/src/player.js
+++ b/src/player.js
@@ -1,10 +1,11 @@
-import FieldCreation from './gameFields/fieldCreation';
-import GameBoard from './gameBoard';
-import Ship from './ships';
+import FieldCreation from './gameFields/fieldCreation.js';
+import GameBoard from './gameBoard.js';
+import Ship from './ships.js';
 import panVertical from './images/pan-vertical.svg';
 import panHorizontal from './images/pan-horizontal.svg';
+import promptSync from 'prompt-sync';
 
-const prompt = require('prompt-sync')();
+const prompt = promptSync();
 
 class Player {
     constructor(name) {

--- a/tests/__mocks__/fileMock.js
+++ b/tests/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+export default '';

--- a/tests/computer.test.js
+++ b/tests/computer.test.js
@@ -1,7 +1,6 @@
-const { Computer } = require('../src/computer');
-const { Player } = require('../src/player');
-const { Ship } = require('../src/ships');
-const prompt = require('prompt-sync')();
+import Computer from '../src/computer.js';
+import Player from '../src/player.js';
+import Ship from '../src/ships.js';
 
 describe('This suite will test the Computer class functionality', () => {
     let computer;

--- a/tests/gameLoop.test.js
+++ b/tests/gameLoop.test.js
@@ -1,8 +1,7 @@
-const { GameLoop } = require('../src/gameFunctions/gameLoop');
-const { inputHandler } = require('../src/gameFunctions/inputHandler');
-const prompt = require('prompt-sync')();
+import GameLoop from '../src/gameFunctions/gameLoop.js';
+import inputHandler from '../src/gameFunctions/inputHandler.js';
 
-jest.mock('../src/gameFunctions/inputHandler');
+jest.mock('../src/gameFunctions/inputHandler.js');
 
 describe('This suite will test the game loop functionality', () => {
     let game;

--- a/tests/gameboard.test.js
+++ b/tests/gameboard.test.js
@@ -1,5 +1,5 @@
-const { GameBoard } = require('../src/gameBoard');
-const { Ship } = require('../src/ships');
+import GameBoard from '../src/gameBoard.js';
+import Ship from '../src/ships.js';
 
 describe('These suite of test will test the game board functionality', () => {
     let testField;

--- a/tests/player.test.js
+++ b/tests/player.test.js
@@ -1,7 +1,6 @@
-const { Player } = require('../src/player');
-const { Computer } = require('../src/computer');
-const { Ship } = require('../src/ships');
-const prompt = require('prompt-sync')();
+import Player from '../src/player.js';
+import Computer from '../src/computer.js';
+import Ship from '../src/ships.js';
 
 describe('This suite will test the Player class functionality', () => {
     let player;

--- a/tests/ship.test.js
+++ b/tests/ship.test.js
@@ -1,4 +1,4 @@
-const { Ship } = require('../src/ships');
+import Ship from '../src/ships.js';
 
 describe('Ship', () => {
     let testShip;


### PR DESCRIPTION
## Summary
- enable Node ESM by declaring type module and running Jest with experimental vm modules
- switch test files to import syntax and map static assets with Jest config
- update source modules to explicit `.js` import paths

## Testing
- `npm test` *(fails: ReferenceError: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68912a17a51c8322a45f3db0459b0f46